### PR TITLE
Expand Definitions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,6 @@ cache:
 
 git:
   depth: 3
+
+jdk:
+  - oraclejdk8

--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,7 @@ dependencies {
 
     testCompile group: 'junit', name: 'junit', version: '4.11'
     testCompile 'org.spockframework:spock-core:1.0-groovy-2.4'
+    testCompile 'cglib:cglib-nodep:3.2.0'
 }
 
 jar {

--- a/build.gradle
+++ b/build.gradle
@@ -9,10 +9,11 @@ repositories {
 }
 
 dependencies {
-    compile 'org.codehaus.groovy:groovy-all:2.3.11'
+    compile 'org.codehaus.groovy:groovy-all:2.4.5'
     compile 'joda-time:joda-time:2.9'
 
     testCompile group: 'junit', name: 'junit', version: '4.11'
+    testCompile 'org.spockframework:spock-core:1.0-groovy-2.4'
 }
 
 jar {

--- a/build.gradle
+++ b/build.gradle
@@ -11,10 +11,12 @@ repositories {
 dependencies {
     compile 'org.codehaus.groovy:groovy-all:2.4.5'
     compile 'joda-time:joda-time:2.9'
+    compile 'org.codehaus.groovy.modules.http-builder:http-builder:0.7.1'
 
     testCompile group: 'junit', name: 'junit', version: '4.11'
     testCompile 'org.spockframework:spock-core:1.0-groovy-2.4'
     testCompile 'cglib:cglib-nodep:3.2.0'
+    testCompile 'org.mbtest.javabank:javabank-client:0.4.7'
 }
 
 jar {
@@ -22,4 +24,9 @@ jar {
         attributes 'Implementation-Title': 'Automated Boundary Testing',
                 'Implementation-Version': 0.1
     }
+}
+
+//the tests in this package require mountebank to be running on localhost
+test {
+    exclude 'org/araneforseti/boundary/mountebank/**'
 }

--- a/src/main/groovy/org/araneforseti/boundary/ApiHelper.groovy
+++ b/src/main/groovy/org/araneforseti/boundary/ApiHelper.groovy
@@ -1,0 +1,50 @@
+package org.araneforseti.boundary
+
+import groovyx.net.http.HTTPBuilder
+import groovyx.net.http.Method
+
+import static groovyx.net.http.ContentType.JSON
+import static groovyx.net.http.Method.*
+
+class ApiHelper {
+
+    static String baseUri = System.getenv("API_URI") ?: "localhost:8080"
+
+    static Map post(String path, Map bodyParameters = [:], Map queryParameters = [:], Map headerParameters = [:]) {
+        request(POST, path, bodyParameters, queryParameters, headerParameters)
+    }
+
+    static Map get(String path, Map queryParameters = [:], Map headerParameters = [:]) {
+        request(GET, path, null, queryParameters, headerParameters)
+    }
+
+    static Map delete(String path, Map queryParameters = [:], Map headerParameters = [:]) {
+        request(DELETE, path, null, queryParameters, headerParameters)
+    }
+
+    static Map put(String path, Map bodyParameters = [:], Map queryParameters = [:], Map headerParameters = [:]) {
+        request(PUT, path, bodyParameters, queryParameters, headerParameters)
+    }
+
+    static Map patch(String path, Map bodyParameters = [:], Map queryParameters = [:], Map headerParameters = [:]) {
+        request(PATCH, path, bodyParameters, queryParameters, headerParameters)
+    }
+
+    private static Map request(Method method, String path, Map bodyParameters = [:], Map queryParameters = [:], Map headerParameters = [:]) {
+        def api = new HTTPBuilder(baseUri)
+        def response = api.request(method, JSON) {
+            requestContentType = JSON
+            uri.path = path
+            uri.query = queryParameters
+            headers = headerParameters
+            body = bodyParameters
+            response.success = responseHandler
+            response.failure = responseHandler
+        }
+        response as Map
+    }
+
+    static responseHandler = { response, json ->
+        [headers: response.headers, body: json, statusCode: response.status]
+    }
+}

--- a/src/main/groovy/org/araneforseti/boundary/definitions/Definition.groovy
+++ b/src/main/groovy/org/araneforseti/boundary/definitions/Definition.groovy
@@ -67,4 +67,12 @@ class Definition {
 
         return scenarios
     }
+
+    Map getCorrectValue() {
+        Map correctValues = [:]
+        fields.each { field ->
+            correctValues.put(field.name, field.correctValue)
+        }
+        correctValues
+    }
 }

--- a/src/main/groovy/org/araneforseti/boundary/definitions/ExpectedResponse.groovy
+++ b/src/main/groovy/org/araneforseti/boundary/definitions/ExpectedResponse.groovy
@@ -3,11 +3,11 @@ package org.araneforseti.boundary.definitions
 import groovy.transform.EqualsAndHashCode
 
 @EqualsAndHashCode
-class Response {
+class ExpectedResponse {
     int statusCode
     Map body
 
-    Response(Map body, int statusCode = 400) {
+    ExpectedResponse(Map body, int statusCode = 400) {
         this.statusCode = statusCode
         this.body = body
     }

--- a/src/main/groovy/org/araneforseti/boundary/definitions/RequestDefinition.groovy
+++ b/src/main/groovy/org/araneforseti/boundary/definitions/RequestDefinition.groovy
@@ -25,35 +25,53 @@ class RequestDefinition {
         this
     }
 
-    List<RequestScenario> getPossibleRequests() {
+    List<RequestScenario> createRequests() {
+        if(pathDefinition == null) {
+            throw new Exception("Path definition required")
+        }
+        requestsFromPathScenarios() + requestsFromQueryScenarios() + requestsFromBodyScenarios()
+    }
+
+    List<RequestScenario> requestsFromPathScenarios() {
         List<RequestScenario> scenarios = []
         pathDefinition.getScenarios().each { scenario ->
             scenarios << new RequestScenario(
-                    name: scenario.name,
-                    path: scenario.value,
-                    queryParameters: queryDefinition.getCorrectValue(),
-                    bodyParameters: bodyDefinition.getCorrectValue(),
-                    expectedResponse: responseFor(scenario))
+                    scenario.name,
+                    scenario.value,
+                    queryDefinition?.getCorrectValue() ?: [:],
+                    bodyDefinition?.getCorrectValue() ?: [:],
+                    responseFor(scenario))
         }
+        scenarios
+    }
 
-        queryDefinition.getCases().each { scenario ->
-            scenarios << new RequestScenario(
-                    name: scenario.name,
-                    path: pathDefinition.correctPath,
-                    queryParameters: scenario.value,
-                    bodyParameters: bodyDefinition.getCorrectValue(),
-                    expectedResponse: responseFor(scenario))
+    List<RequestScenario> requestsFromQueryScenarios() {
+        List<RequestScenario> scenarios = []
+        if(queryDefinition) {
+            queryDefinition.getCases().each { scenario ->
+                scenarios << new RequestScenario(
+                        scenario.name,
+                        pathDefinition.correctPath,
+                        scenario.value,
+                        bodyDefinition?.getCorrectValue(),
+                        responseFor(scenario))
+            }
         }
+        scenarios
+    }
 
-        bodyDefinition.getCases().each { scenario ->
-            scenarios << new RequestScenario(
-                    name: scenario.name,
-                    path: pathDefinition.correctPath,
-                    queryParameters: queryDefinition.getCorrectValue(),
-                    bodyParameters: scenario.value,
-                    expectedResponse: responseFor(scenario))
+    List<RequestScenario> requestsFromBodyScenarios() {
+        List<RequestScenario> scenarios = []
+        if(bodyDefinition) {
+            bodyDefinition.getCases().each { scenario ->
+                scenarios << new RequestScenario(
+                        scenario.name,
+                        pathDefinition.correctPath,
+                        queryDefinition?.getCorrectValue(),
+                        scenario.value,
+                        responseFor(scenario))
+            }
         }
-
         scenarios
     }
 

--- a/src/main/groovy/org/araneforseti/boundary/definitions/RequestDefinition.groovy
+++ b/src/main/groovy/org/araneforseti/boundary/definitions/RequestDefinition.groovy
@@ -29,6 +29,7 @@ class RequestDefinition {
         List<RequestScenario> scenarios = []
         pathDefinition.getScenarios().each { scenario ->
             scenarios << new RequestScenario(
+                    name: scenario.name,
                     path: scenario.value,
                     queryParameters: queryDefinition.getCorrectValue(),
                     bodyParameters: bodyDefinition.getCorrectValue(),
@@ -37,6 +38,7 @@ class RequestDefinition {
 
         queryDefinition.getCases().each { scenario ->
             scenarios << new RequestScenario(
+                    name: scenario.name,
                     path: pathDefinition.correctPath,
                     queryParameters: scenario.value,
                     bodyParameters: bodyDefinition.getCorrectValue(),
@@ -45,6 +47,7 @@ class RequestDefinition {
 
         bodyDefinition.getCases().each { scenario ->
             scenarios << new RequestScenario(
+                    name: scenario.name,
                     path: pathDefinition.correctPath,
                     queryParameters: queryDefinition.getCorrectValue(),
                     bodyParameters: scenario.value,

--- a/src/main/groovy/org/araneforseti/boundary/definitions/RequestDefinition.groovy
+++ b/src/main/groovy/org/araneforseti/boundary/definitions/RequestDefinition.groovy
@@ -1,0 +1,64 @@
+package org.araneforseti.boundary.definitions
+
+import org.araneforseti.boundary.definitions.path.PathDefinition
+import org.araneforseti.boundary.scenarios.BoundaryScenario
+import org.araneforseti.boundary.scenarios.RequestScenario
+
+class RequestDefinition {
+
+    PathDefinition pathDefinition
+    Definition queryDefinition
+    Definition bodyDefinition
+
+    RequestDefinition withPathDefinition(PathDefinition pathDefinition) {
+        this.pathDefinition = pathDefinition
+        this
+    }
+
+    RequestDefinition withQueryDefinition(Definition queryDefinition) {
+        this.queryDefinition = queryDefinition
+        this
+    }
+
+    RequestDefinition withBodyDefinition(Definition bodyDefinition) {
+        this.bodyDefinition = bodyDefinition
+        this
+    }
+
+    List<RequestScenario> getPossibleRequests() {
+        List<RequestScenario> scenarios = []
+        pathDefinition.getScenarios().each { scenario ->
+            scenarios << new RequestScenario(
+                    path: scenario.value,
+                    queryParameters: queryDefinition.getCorrectValue(),
+                    bodyParameters: bodyDefinition.getCorrectValue(),
+                    expectedResponse: responseFor(scenario))
+        }
+
+        queryDefinition.getCases().each { scenario ->
+            scenarios << new RequestScenario(
+                    path: pathDefinition.correctPath,
+                    queryParameters: scenario.value,
+                    bodyParameters: bodyDefinition.getCorrectValue(),
+                    expectedResponse: responseFor(scenario))
+        }
+
+        bodyDefinition.getCases().each { scenario ->
+            scenarios << new RequestScenario(
+                    path: pathDefinition.correctPath,
+                    queryParameters: queryDefinition.getCorrectValue(),
+                    bodyParameters: scenario.value,
+                    expectedResponse: responseFor(scenario))
+        }
+
+        scenarios
+    }
+
+    private static Response responseFor(BoundaryScenario scenario) {
+        scenario.expectedResponse ?: defaultResponse(scenario)
+    }
+
+    private static Response defaultResponse(BoundaryScenario scenario) {
+        new Response([message: scenario.expectedMessage])
+    }
+}

--- a/src/main/groovy/org/araneforseti/boundary/definitions/RequestDefinition.groovy
+++ b/src/main/groovy/org/araneforseti/boundary/definitions/RequestDefinition.groovy
@@ -75,11 +75,11 @@ class RequestDefinition {
         scenarios
     }
 
-    private static Response responseFor(BoundaryScenario scenario) {
+    private static ExpectedResponse responseFor(BoundaryScenario scenario) {
         scenario.expectedResponse ?: defaultResponse(scenario)
     }
 
-    private static Response defaultResponse(BoundaryScenario scenario) {
-        new Response([message: scenario.expectedMessage])
+    private static ExpectedResponse defaultResponse(BoundaryScenario scenario) {
+        new ExpectedResponse([message: scenario.expectedMessage])
     }
 }

--- a/src/main/groovy/org/araneforseti/boundary/definitions/Response.groovy
+++ b/src/main/groovy/org/araneforseti/boundary/definitions/Response.groovy
@@ -1,0 +1,14 @@
+package org.araneforseti.boundary.definitions
+
+import groovy.transform.EqualsAndHashCode
+
+@EqualsAndHashCode
+class Response {
+    int statusCode
+    Map body
+
+    Response(Map body, int statusCode = 400) {
+        this.statusCode = statusCode
+        this.body = body
+    }
+}

--- a/src/main/groovy/org/araneforseti/boundary/definitions/path/Identifier.groovy
+++ b/src/main/groovy/org/araneforseti/boundary/definitions/path/Identifier.groovy
@@ -15,7 +15,7 @@ class Identifier implements PathParameter{
     }
 
     Identifier withScenario(String value, Response expectedResponse) {
-        scenarios << new BoundaryScenario(this.name, expectedResponse, value)
+        scenarios << new BoundaryScenario("$name as $value", expectedResponse, value)
         this
     }
 

--- a/src/main/groovy/org/araneforseti/boundary/definitions/path/Identifier.groovy
+++ b/src/main/groovy/org/araneforseti/boundary/definitions/path/Identifier.groovy
@@ -1,5 +1,6 @@
 package org.araneforseti.boundary.definitions.path
 
+import org.araneforseti.boundary.definitions.Response
 import org.araneforseti.boundary.scenarios.BoundaryScenario
 
 class Identifier implements PathParameter{
@@ -13,9 +14,13 @@ class Identifier implements PathParameter{
         this.correctValue = correctValue
     }
 
-    Identifier withScenario(String value, String expectedMessage) {
-        scenarios << new BoundaryScenario(this.name, expectedMessage, value)
+    Identifier withScenario(String value, Response expectedResponse) {
+        scenarios << new BoundaryScenario(this.name, expectedResponse, value)
         this
+    }
+
+    String getName() {
+        name
     }
 
     List<BoundaryScenario> getScenarios() {

--- a/src/main/groovy/org/araneforseti/boundary/definitions/path/Identifier.groovy
+++ b/src/main/groovy/org/araneforseti/boundary/definitions/path/Identifier.groovy
@@ -1,6 +1,6 @@
 package org.araneforseti.boundary.definitions.path
 
-import org.araneforseti.boundary.definitions.Response
+import org.araneforseti.boundary.definitions.ExpectedResponse
 import org.araneforseti.boundary.scenarios.BoundaryScenario
 
 class Identifier implements PathParameter{
@@ -14,7 +14,7 @@ class Identifier implements PathParameter{
         this.correctValue = correctValue
     }
 
-    Identifier withScenario(String value, Response expectedResponse) {
+    Identifier withScenario(String value, ExpectedResponse expectedResponse) {
         scenarios << new BoundaryScenario("$name as $value", expectedResponse, value)
         this
     }

--- a/src/main/groovy/org/araneforseti/boundary/definitions/path/Identifier.groovy
+++ b/src/main/groovy/org/araneforseti/boundary/definitions/path/Identifier.groovy
@@ -1,0 +1,29 @@
+package org.araneforseti.boundary.definitions.path
+
+import org.araneforseti.boundary.scenarios.BoundaryScenario
+
+class Identifier implements PathParameter{
+
+    private List<BoundaryScenario> scenarios = []
+    private String name
+    private String correctValue
+
+    Identifier(String name, String correctValue) {
+        this.name = name
+        this.correctValue = correctValue
+    }
+
+    Identifier withScenario(String value, String expectedMessage) {
+        scenarios << new BoundaryScenario(this.name, expectedMessage, value)
+        this
+    }
+
+    List<BoundaryScenario> getScenarios() {
+        scenarios
+    }
+
+    @Override
+    String getCorrectValue() {
+        correctValue
+    }
+}

--- a/src/main/groovy/org/araneforseti/boundary/definitions/path/PathDefinition.groovy
+++ b/src/main/groovy/org/araneforseti/boundary/definitions/path/PathDefinition.groovy
@@ -24,7 +24,7 @@ class PathDefinition {
             pathParameter.scenarios.collect { scenario ->
                 new BoundaryScenario(
                         scenario.name,
-                        scenario.expectedMessage,
+                        scenario.expectedResponse,
                         createPathForScenario(pathParameter, scenario.value))
             }
         }

--- a/src/main/groovy/org/araneforseti/boundary/definitions/path/PathDefinition.groovy
+++ b/src/main/groovy/org/araneforseti/boundary/definitions/path/PathDefinition.groovy
@@ -6,6 +6,11 @@ class PathDefinition {
 
     private List<PathParameter> pathParameters = []
 
+    PathDefinition withResource(String resource) {
+        pathParameters << new Resource(resource)
+        this
+    }
+
     PathDefinition withParameter(PathParameter pathParameter) {
         pathParameters << pathParameter
         this

--- a/src/main/groovy/org/araneforseti/boundary/definitions/path/PathDefinition.groovy
+++ b/src/main/groovy/org/araneforseti/boundary/definitions/path/PathDefinition.groovy
@@ -1,0 +1,44 @@
+package org.araneforseti.boundary.definitions.path
+
+import org.araneforseti.boundary.scenarios.BoundaryScenario
+
+class PathDefinition {
+
+    private List<PathParameter> pathParameters = []
+
+    PathDefinition withParameter(PathParameter pathParameter) {
+        pathParameters << pathParameter
+        this
+    }
+
+    String getCorrectPath() {
+        String correctPath = ""
+        pathParameters.each {
+            correctPath += "/${it.getCorrectValue()}"
+        }
+        return correctPath
+    }
+
+    List<BoundaryScenario> getScenarios() {
+        pathParameters.collectMany { pathParameter ->
+            pathParameter.scenarios.collect { scenario ->
+                new BoundaryScenario(
+                        scenario.name,
+                        scenario.expectedMessage,
+                        createPathForScenario(pathParameter, scenario.value))
+            }
+        }
+    }
+
+    private String createPathForScenario(PathParameter currentPathParameter, String scenarioValue) {
+        String path = ""
+        pathParameters.each { pathParameter ->
+            if (pathParameter == currentPathParameter) {
+                path += "/${scenarioValue}"
+            } else {
+                path += "/${pathParameter.getCorrectValue()}"
+            }
+        }
+        path
+    }
+}

--- a/src/main/groovy/org/araneforseti/boundary/definitions/path/PathParameter.groovy
+++ b/src/main/groovy/org/araneforseti/boundary/definitions/path/PathParameter.groovy
@@ -1,0 +1,8 @@
+package org.araneforseti.boundary.definitions.path
+
+import org.araneforseti.boundary.scenarios.BoundaryScenario
+
+interface PathParameter {
+    String getCorrectValue()
+    List<BoundaryScenario> getScenarios()
+}

--- a/src/main/groovy/org/araneforseti/boundary/definitions/path/Resource.groovy
+++ b/src/main/groovy/org/araneforseti/boundary/definitions/path/Resource.groovy
@@ -1,0 +1,21 @@
+package org.araneforseti.boundary.definitions.path
+
+import org.araneforseti.boundary.scenarios.BoundaryScenario
+
+class Resource implements PathParameter {
+    private String resource
+
+    Resource(String resource) {
+        this.resource = resource
+    }
+
+    @Override
+    String getCorrectValue() {
+        resource
+    }
+
+    @Override
+    List<BoundaryScenario> getScenarios() {
+        []
+    }
+}

--- a/src/main/groovy/org/araneforseti/boundary/fields/ObjectField.groovy
+++ b/src/main/groovy/org/araneforseti/boundary/fields/ObjectField.groovy
@@ -18,6 +18,10 @@ class ObjectField extends Field {
     List<BoundaryScenario> getCases() {
         List<BoundaryScenario> scenarios = []
 
+        if(isRequired) {
+            scenarios << new BoundaryScenario("$name as null", "$name is a required field", null)
+        }
+
         fieldList.each{ field ->
             if(field.isRequired) {
                 scenarios.add(missingFieldScenario(field))

--- a/src/main/groovy/org/araneforseti/boundary/scenarios/BoundaryScenario.groovy
+++ b/src/main/groovy/org/araneforseti/boundary/scenarios/BoundaryScenario.groovy
@@ -1,5 +1,10 @@
 package org.araneforseti.boundary.scenarios
 
+import groovy.transform.EqualsAndHashCode
+import groovy.transform.ToString
+
+@EqualsAndHashCode
+@ToString
 class BoundaryScenario {
     String expectedMessage
     def value = null

--- a/src/main/groovy/org/araneforseti/boundary/scenarios/BoundaryScenario.groovy
+++ b/src/main/groovy/org/araneforseti/boundary/scenarios/BoundaryScenario.groovy
@@ -2,6 +2,7 @@ package org.araneforseti.boundary.scenarios
 
 import groovy.transform.EqualsAndHashCode
 import groovy.transform.ToString
+import org.araneforseti.boundary.definitions.Response
 
 @EqualsAndHashCode
 @ToString
@@ -9,10 +10,17 @@ class BoundaryScenario {
     String expectedMessage
     def value = null
     String name
+    Response expectedResponse
 
     BoundaryScenario(String name, String expectedMessage, value) {
         this.name = name
         this.expectedMessage = expectedMessage
         this.value = value
+    }
+
+    BoundaryScenario(String name, Response expectedResponse, Object value) {
+        this.name = name
+        this.value = value
+        this.expectedResponse = expectedResponse
     }
 }

--- a/src/main/groovy/org/araneforseti/boundary/scenarios/BoundaryScenario.groovy
+++ b/src/main/groovy/org/araneforseti/boundary/scenarios/BoundaryScenario.groovy
@@ -2,7 +2,7 @@ package org.araneforseti.boundary.scenarios
 
 import groovy.transform.EqualsAndHashCode
 import groovy.transform.ToString
-import org.araneforseti.boundary.definitions.Response
+import org.araneforseti.boundary.definitions.ExpectedResponse
 
 @EqualsAndHashCode
 @ToString
@@ -10,7 +10,7 @@ class BoundaryScenario {
     String expectedMessage
     def value = null
     String name
-    Response expectedResponse
+    ExpectedResponse expectedResponse
 
     BoundaryScenario(String name, String expectedMessage, value) {
         this.name = name
@@ -18,7 +18,7 @@ class BoundaryScenario {
         this.value = value
     }
 
-    BoundaryScenario(String name, Response expectedResponse, Object value) {
+    BoundaryScenario(String name, ExpectedResponse expectedResponse, Object value) {
         this.name = name
         this.value = value
         this.expectedResponse = expectedResponse

--- a/src/main/groovy/org/araneforseti/boundary/scenarios/RequestScenario.groovy
+++ b/src/main/groovy/org/araneforseti/boundary/scenarios/RequestScenario.groovy
@@ -1,15 +1,15 @@
 package org.araneforseti.boundary.scenarios
 
-import org.araneforseti.boundary.definitions.Response
+import org.araneforseti.boundary.definitions.ExpectedResponse
 
 class RequestScenario {
     String name
     String path
     Map queryParameters
     Map bodyParameters
-    Response expectedResponse
+    ExpectedResponse expectedResponse
 
-    RequestScenario(String name, String path, Map queryParameters, Map bodyParameters, Response expectedResponse) {
+    RequestScenario(String name, String path, Map queryParameters, Map bodyParameters, ExpectedResponse expectedResponse) {
         this.name = name
         this.path = path
         this.queryParameters = queryParameters ?: [:]

--- a/src/main/groovy/org/araneforseti/boundary/scenarios/RequestScenario.groovy
+++ b/src/main/groovy/org/araneforseti/boundary/scenarios/RequestScenario.groovy
@@ -1,0 +1,10 @@
+package org.araneforseti.boundary.scenarios
+
+import org.araneforseti.boundary.definitions.Response
+
+class RequestScenario {
+    String path
+    Map queryParameters
+    Map bodyParameters
+    Response expectedResponse
+}

--- a/src/main/groovy/org/araneforseti/boundary/scenarios/RequestScenario.groovy
+++ b/src/main/groovy/org/araneforseti/boundary/scenarios/RequestScenario.groovy
@@ -3,6 +3,7 @@ package org.araneforseti.boundary.scenarios
 import org.araneforseti.boundary.definitions.Response
 
 class RequestScenario {
+    String name
     String path
     Map queryParameters
     Map bodyParameters

--- a/src/main/groovy/org/araneforseti/boundary/scenarios/RequestScenario.groovy
+++ b/src/main/groovy/org/araneforseti/boundary/scenarios/RequestScenario.groovy
@@ -8,4 +8,12 @@ class RequestScenario {
     Map queryParameters
     Map bodyParameters
     Response expectedResponse
+
+    RequestScenario(String name, String path, Map queryParameters, Map bodyParameters, Response expectedResponse) {
+        this.name = name
+        this.path = path
+        this.queryParameters = queryParameters ?: [:]
+        this.bodyParameters = bodyParameters ?: [:]
+        this.expectedResponse = expectedResponse
+    }
 }

--- a/src/test/groovy/org/araneforseti/boundary/TestUtil.groovy
+++ b/src/test/groovy/org/araneforseti/boundary/TestUtil.groovy
@@ -1,7 +1,7 @@
 package org.araneforseti.boundary
 
 import org.araneforseti.boundary.definitions.Definition
-import org.araneforseti.boundary.definitions.Response
+import org.araneforseti.boundary.definitions.ExpectedResponse
 import org.araneforseti.boundary.fields.Field
 
 class TestUtil {
@@ -37,7 +37,7 @@ class TestUtil {
 
     static final String responseKey = "message"
 
-    static Response responseFor(String message, int statusCode = 400) {
-        new Response([(responseKey): message], statusCode)
+    static ExpectedResponse responseFor(String message, int statusCode = 400) {
+        new ExpectedResponse([(responseKey): message], statusCode)
     }
 }

--- a/src/test/groovy/org/araneforseti/boundary/TestUtil.groovy
+++ b/src/test/groovy/org/araneforseti/boundary/TestUtil.groovy
@@ -1,6 +1,7 @@
 package org.araneforseti.boundary
 
 import org.araneforseti.boundary.definitions.Definition
+import org.araneforseti.boundary.definitions.Response
 import org.araneforseti.boundary.fields.Field
 
 class TestUtil {
@@ -32,5 +33,11 @@ class TestUtil {
             }
         }
         return found
+    }
+
+    static final String responseKey = "message"
+
+    static Response responseFor(String message, int statusCode = 400) {
+        new Response([(responseKey): message], statusCode)
     }
 }

--- a/src/test/groovy/org/araneforseti/boundary/definitions/DefinitionTest.groovy
+++ b/src/test/groovy/org/araneforseti/boundary/definitions/DefinitionTest.groovy
@@ -11,10 +11,10 @@ class DefinitionTest {
         Definition definition = new Definition()
                 .withField(new BooleanField("bool", true))
                 .withField(new BooleanField("bool2", false))
-        scenarios_contains_value([bool: null, bool2: true], definition)
-        scenarios_contains_value([bool: "a", bool2: true], definition)
-        scenarios_contains_value([bool: 2, bool2: true], definition)
-        scenarios_contains_value([bool2: "a", bool: true], definition)
-        scenarios_contains_value([bool2: 2, bool: true], definition)
+        assert scenarios_contains_value([bool: null, bool2: true], definition)
+        assert scenarios_contains_value([bool: "a", bool2: true], definition)
+        assert scenarios_contains_value([bool: 2, bool2: true], definition)
+        assert scenarios_contains_value([bool2: "a", bool: true], definition)
+        assert scenarios_contains_value([bool2: 2, bool: true], definition)
     }
 }

--- a/src/test/groovy/org/araneforseti/boundary/definitions/PathDefinitionTest.groovy
+++ b/src/test/groovy/org/araneforseti/boundary/definitions/PathDefinitionTest.groovy
@@ -1,0 +1,83 @@
+package org.araneforseti.boundary.definitions
+
+import org.araneforseti.boundary.definitions.path.Identifier
+import org.araneforseti.boundary.definitions.path.PathDefinition
+import org.araneforseti.boundary.definitions.path.Resource
+import org.araneforseti.boundary.scenarios.BoundaryScenario
+import spock.lang.Specification
+
+class PathDefinitionTest extends Specification {
+
+    void 'should build a path definition with a resource'() {
+        given:
+        PathDefinition pathDefinition = new PathDefinition()
+                .withParameter(new Resource("cars"))
+
+        expect:
+        pathDefinition.getCorrectPath() == "/cars"
+    }
+
+    void 'should create no cases for a path with no identifier'() {
+        given:
+        PathDefinition pathDefinition = new PathDefinition()
+                .withParameter(new Resource("cars"))
+
+        expect:
+        pathDefinition.getScenarios() == []
+    }
+
+    void 'should build a path definition with a resource and an identifier'() {
+        given:
+        PathDefinition pathDefinition = new PathDefinition()
+                .withParameter(new Resource("cars"))
+                .withParameter(new Identifier("carId", "1000043"))
+
+        expect:
+        pathDefinition.getCorrectPath() == "/cars/1000043"
+    }
+
+    void 'should create scenarios based on the identifier'() {
+        given:
+        Identifier idField = new Identifier("carId", "1000043")
+                .withScenario("abc", "carId abc not found")
+                .withScenario("!@#!@#", "carId !@#!@# not found")
+        PathDefinition pathDefinition = new PathDefinition()
+                .withParameter(new Resource("cars"))
+                .withParameter(idField)
+
+        expect:
+        pathDefinition.getScenarios() == [new BoundaryScenario("carId", "carId abc not found", "/cars/abc"),
+                                          new BoundaryScenario("carId", "carId !@#!@# not found", "/cars/!@#!@#")]
+    }
+
+    void 'should build a path definition with multiple resources and identifiers'() {
+        given:
+        PathDefinition pathDefinition = new PathDefinition()
+                .withParameter(new Resource("cars"))
+                .withParameter(new Identifier("carId", "1000043"))
+                .withParameter(new Resource("wheels"))
+                .withParameter(new Identifier("wheelId", "FrontRight"))
+
+        expect:
+        pathDefinition.getCorrectPath() == "/cars/1000043/wheels/FrontRight"
+    }
+
+    void 'should create scenarios based on all the identifiers'() {
+        given:
+        Identifier carIdField = new Identifier("carId", "1000043")
+                .withScenario("abc", "carId abc not found")
+                .withScenario("!@#!@#", "carId !@#!@# not found")
+        Identifier wheelIdField = new Identifier("wheelId", "FrontRight")
+                .withScenario("1234", "wheelId 1234 not found")
+        PathDefinition pathDefinition = new PathDefinition()
+                .withParameter(new Resource("cars"))
+                .withParameter(carIdField)
+                .withParameter(new Resource("wheels"))
+                .withParameter(wheelIdField)
+
+        expect:
+        pathDefinition.getScenarios() == [new BoundaryScenario("carId", "carId abc not found", "/cars/abc/wheels/FrontRight"),
+                                          new BoundaryScenario("carId", "carId !@#!@# not found", "/cars/!@#!@#/wheels/FrontRight"),
+                                          new BoundaryScenario("wheelId", "wheelId 1234 not found", "/cars/1000043/wheels/1234")]
+    }
+}

--- a/src/test/groovy/org/araneforseti/boundary/definitions/PathDefinitionTest.groovy
+++ b/src/test/groovy/org/araneforseti/boundary/definitions/PathDefinitionTest.groovy
@@ -6,12 +6,37 @@ import org.araneforseti.boundary.definitions.path.Resource
 import org.araneforseti.boundary.scenarios.BoundaryScenario
 import spock.lang.Specification
 
+import static org.araneforseti.boundary.TestUtil.responseFor
+
 class PathDefinitionTest extends Specification {
+    private Response response1
+    private Response response2
+    private Response response3
+    private Identifier carIdWithScenarios
+    private Identifier wheelIdWithScenarios
+    private Resource carResource
+    private Identifier carId
+    private Resource wheelResource = new Resource("wheels")
+    private Identifier wheelId
+
+    void setup() {
+        carResource = new Resource("cars")
+        response1 = responseFor("carId abc not found")
+        response2 = responseFor("carId !@#!@# not found")
+        response3 = responseFor("wheelId 1234 not found")
+        carId = new Identifier("carId", "1000043")
+        carIdWithScenarios = carId
+                .withScenario("abc", response1)
+                .withScenario("!@#!@#", response2)
+        wheelId = new Identifier("wheelId", "FrontRight")
+        wheelIdWithScenarios = wheelId
+                .withScenario("1234", response3)
+    }
 
     void 'should build a path definition with a resource'() {
         given:
         PathDefinition pathDefinition = new PathDefinition()
-                .withParameter(new Resource("cars"))
+                .withParameter(carResource)
 
         expect:
         pathDefinition.getCorrectPath() == "/cars"
@@ -20,7 +45,7 @@ class PathDefinitionTest extends Specification {
     void 'should create no cases for a path with no identifier'() {
         given:
         PathDefinition pathDefinition = new PathDefinition()
-                .withParameter(new Resource("cars"))
+                .withParameter(carResource)
 
         expect:
         pathDefinition.getScenarios() == []
@@ -29,8 +54,8 @@ class PathDefinitionTest extends Specification {
     void 'should build a path definition with a resource and an identifier'() {
         given:
         PathDefinition pathDefinition = new PathDefinition()
-                .withParameter(new Resource("cars"))
-                .withParameter(new Identifier("carId", "1000043"))
+                .withParameter(carResource)
+                .withParameter(carId)
 
         expect:
         pathDefinition.getCorrectPath() == "/cars/1000043"
@@ -38,25 +63,22 @@ class PathDefinitionTest extends Specification {
 
     void 'should create scenarios based on the identifier'() {
         given:
-        Identifier idField = new Identifier("carId", "1000043")
-                .withScenario("abc", "carId abc not found")
-                .withScenario("!@#!@#", "carId !@#!@# not found")
         PathDefinition pathDefinition = new PathDefinition()
-                .withParameter(new Resource("cars"))
-                .withParameter(idField)
+                .withParameter(carResource)
+                .withParameter(carIdWithScenarios)
 
         expect:
-        pathDefinition.getScenarios() == [new BoundaryScenario("carId", "carId abc not found", "/cars/abc"),
-                                          new BoundaryScenario("carId", "carId !@#!@# not found", "/cars/!@#!@#")]
+        pathDefinition.getScenarios() == [new BoundaryScenario(carIdWithScenarios.getName(), response1, "/cars/abc"),
+                                          new BoundaryScenario(carIdWithScenarios.getName(), response2, "/cars/!@#!@#")]
     }
 
     void 'should build a path definition with multiple resources and identifiers'() {
         given:
         PathDefinition pathDefinition = new PathDefinition()
-                .withParameter(new Resource("cars"))
-                .withParameter(new Identifier("carId", "1000043"))
-                .withParameter(new Resource("wheels"))
-                .withParameter(new Identifier("wheelId", "FrontRight"))
+                .withParameter(carResource)
+                .withParameter(carId)
+                .withParameter(wheelResource)
+                .withParameter(wheelId)
 
         expect:
         pathDefinition.getCorrectPath() == "/cars/1000043/wheels/FrontRight"
@@ -64,20 +86,15 @@ class PathDefinitionTest extends Specification {
 
     void 'should create scenarios based on all the identifiers'() {
         given:
-        Identifier carIdField = new Identifier("carId", "1000043")
-                .withScenario("abc", "carId abc not found")
-                .withScenario("!@#!@#", "carId !@#!@# not found")
-        Identifier wheelIdField = new Identifier("wheelId", "FrontRight")
-                .withScenario("1234", "wheelId 1234 not found")
         PathDefinition pathDefinition = new PathDefinition()
-                .withParameter(new Resource("cars"))
-                .withParameter(carIdField)
-                .withParameter(new Resource("wheels"))
-                .withParameter(wheelIdField)
+                .withParameter(carResource)
+                .withParameter(this.carIdWithScenarios)
+                .withParameter(wheelResource)
+                .withParameter(this.wheelIdWithScenarios)
 
         expect:
-        pathDefinition.getScenarios() == [new BoundaryScenario("carId", "carId abc not found", "/cars/abc/wheels/FrontRight"),
-                                          new BoundaryScenario("carId", "carId !@#!@# not found", "/cars/!@#!@#/wheels/FrontRight"),
-                                          new BoundaryScenario("wheelId", "wheelId 1234 not found", "/cars/1000043/wheels/1234")]
+        pathDefinition.getScenarios() == [new BoundaryScenario("carId", response1, "/cars/abc/wheels/FrontRight"),
+                                          new BoundaryScenario("carId", response2, "/cars/!@#!@#/wheels/FrontRight"),
+                                          new BoundaryScenario("wheelId", response3, "/cars/1000043/wheels/1234")]
     }
 }

--- a/src/test/groovy/org/araneforseti/boundary/definitions/PathDefinitionTest.groovy
+++ b/src/test/groovy/org/araneforseti/boundary/definitions/PathDefinitionTest.groovy
@@ -9,9 +9,9 @@ import spock.lang.Specification
 import static org.araneforseti.boundary.TestUtil.responseFor
 
 class PathDefinitionTest extends Specification {
-    private Response response1
-    private Response response2
-    private Response response3
+    private ExpectedResponse response1
+    private ExpectedResponse response2
+    private ExpectedResponse response3
     private Identifier carIdWithScenarios
     private Identifier wheelIdWithScenarios
     private Resource carResource

--- a/src/test/groovy/org/araneforseti/boundary/definitions/PathDefinitionTest.groovy
+++ b/src/test/groovy/org/araneforseti/boundary/definitions/PathDefinitionTest.groovy
@@ -68,8 +68,8 @@ class PathDefinitionTest extends Specification {
                 .withParameter(carIdWithScenarios)
 
         expect:
-        pathDefinition.getScenarios() == [new BoundaryScenario(carIdWithScenarios.getName(), response1, "/cars/abc"),
-                                          new BoundaryScenario(carIdWithScenarios.getName(), response2, "/cars/!@#!@#")]
+        pathDefinition.getScenarios() == [new BoundaryScenario("carId as abc", response1, "/cars/abc"),
+                                          new BoundaryScenario("carId as !@#!@#", response2, "/cars/!@#!@#")]
     }
 
     void 'should build a path definition with multiple resources and identifiers'() {
@@ -93,8 +93,8 @@ class PathDefinitionTest extends Specification {
                 .withParameter(this.wheelIdWithScenarios)
 
         expect:
-        pathDefinition.getScenarios() == [new BoundaryScenario("carId", response1, "/cars/abc/wheels/FrontRight"),
-                                          new BoundaryScenario("carId", response2, "/cars/!@#!@#/wheels/FrontRight"),
-                                          new BoundaryScenario("wheelId", response3, "/cars/1000043/wheels/1234")]
+        pathDefinition.getScenarios() == [new BoundaryScenario("carId as abc", response1, "/cars/abc/wheels/FrontRight"),
+                                          new BoundaryScenario("carId as !@#!@#", response2, "/cars/!@#!@#/wheels/FrontRight"),
+                                          new BoundaryScenario("wheelId as 1234", response3, "/cars/1000043/wheels/1234")]
     }
 }

--- a/src/test/groovy/org/araneforseti/boundary/definitions/RequestDefinitionTest.groovy
+++ b/src/test/groovy/org/araneforseti/boundary/definitions/RequestDefinitionTest.groovy
@@ -43,6 +43,7 @@ class RequestDefinitionTest extends Specification {
 
         then:
         requestScenarios.size() == 3
+        requestScenarios[0].name == "carId as incorrect"
         requestScenarios[0].path == "/cars/incorrect"
         requestScenarios[0].queryParameters == [queryStringField: "correct value 1"]
         requestScenarios[0].bodyParameters == [bodyStringField: "correct value 2"]
@@ -55,6 +56,7 @@ class RequestDefinitionTest extends Specification {
 
         then:
         requestScenarios.size() == 3
+        requestScenarios[1].name == "queryStringField as a number"
         requestScenarios[1].path == "/cars/123"
         requestScenarios[1].queryParameters == [queryStringField: 1]
         requestScenarios[1].bodyParameters == [bodyStringField: "correct value 2"]
@@ -67,6 +69,7 @@ class RequestDefinitionTest extends Specification {
 
         then:
         requestScenarios.size() == 3
+        requestScenarios[2].name == "bodyStringField as a number"
         requestScenarios[2].path == "/cars/123"
         requestScenarios[2].queryParameters == [queryStringField: "correct value 1"]
         requestScenarios[2].bodyParameters == [bodyStringField: 1]

--- a/src/test/groovy/org/araneforseti/boundary/definitions/RequestDefinitionTest.groovy
+++ b/src/test/groovy/org/araneforseti/boundary/definitions/RequestDefinitionTest.groovy
@@ -1,0 +1,75 @@
+package org.araneforseti.boundary.definitions
+
+import org.araneforseti.boundary.definitions.path.Identifier
+import org.araneforseti.boundary.definitions.path.PathDefinition
+import org.araneforseti.boundary.definitions.path.Resource
+import org.araneforseti.boundary.fields.StringField
+import org.araneforseti.boundary.scenarios.RequestScenario
+import spock.lang.Specification
+
+import static org.araneforseti.boundary.TestUtil.responseFor
+
+class RequestDefinitionTest extends Specification {
+
+    private PathDefinition pathDefinition
+    private Definition queryDefinition
+    private Definition bodyDefinition
+    private Response response1
+    private Response response2
+    private Response response3
+    private RequestDefinition requestDefinition
+
+    void setup() {
+        response1 = responseFor("invalid carId", 404)
+        response2 = responseFor("queryStringField must be a String", 400)
+        response3 = responseFor("bodyStringField must be a String", 400)
+        pathDefinition = new PathDefinition()
+                .withParameter(new Resource("cars"))
+                .withParameter(new Identifier("carId", "123")
+                    .withScenario("incorrect", response1))
+        queryDefinition = new Definition()
+                .withField(new StringField("queryStringField", "correct value 1", false))
+        bodyDefinition = new Definition()
+                .withField(new StringField("bodyStringField", "correct value 2", false))
+        requestDefinition = new RequestDefinition()
+                .withPathDefinition(pathDefinition)
+                .withQueryDefinition(queryDefinition)
+                .withBodyDefinition(bodyDefinition)
+    }
+
+    void 'should create requests for all scenarios from the path definition'() {
+        when:
+        List<RequestScenario> requestScenarios = requestDefinition.getPossibleRequests()
+
+        then:
+        requestScenarios.size() == 3
+        requestScenarios[0].path == "/cars/incorrect"
+        requestScenarios[0].queryParameters == [queryStringField: "correct value 1"]
+        requestScenarios[0].bodyParameters == [bodyStringField: "correct value 2"]
+        requestScenarios[0].expectedResponse == response1
+    }
+
+    void 'should create requests for all scenarios from the query definition'() {
+        when:
+        List<RequestScenario> requestScenarios = requestDefinition.getPossibleRequests()
+
+        then:
+        requestScenarios.size() == 3
+        requestScenarios[1].path == "/cars/123"
+        requestScenarios[1].queryParameters == [queryStringField: 1]
+        requestScenarios[1].bodyParameters == [bodyStringField: "correct value 2"]
+        requestScenarios[1].expectedResponse == response2
+    }
+
+    void 'should create requests for all scenarios from the body definition'() {
+        when:
+        List<RequestScenario> requestScenarios = requestDefinition.getPossibleRequests()
+
+        then:
+        requestScenarios.size() == 3
+        requestScenarios[2].path == "/cars/123"
+        requestScenarios[2].queryParameters == [queryStringField: "correct value 1"]
+        requestScenarios[2].bodyParameters == [bodyStringField: 1]
+        requestScenarios[2].expectedResponse == response3
+    }
+}

--- a/src/test/groovy/org/araneforseti/boundary/definitions/RequestDefinitionTest.groovy
+++ b/src/test/groovy/org/araneforseti/boundary/definitions/RequestDefinitionTest.groovy
@@ -14,9 +14,9 @@ class RequestDefinitionTest extends Specification {
     private PathDefinition pathDefinition
     private Definition queryDefinition
     private Definition bodyDefinition
-    private Response response1
-    private Response response2
-    private Response response3
+    private ExpectedResponse response1
+    private ExpectedResponse response2
+    private ExpectedResponse response3
     private RequestDefinition requestDefinition
 
     void setup() {

--- a/src/test/groovy/org/araneforseti/boundary/definitions/RequestDefinitionTest.groovy
+++ b/src/test/groovy/org/araneforseti/boundary/definitions/RequestDefinitionTest.groovy
@@ -39,7 +39,7 @@ class RequestDefinitionTest extends Specification {
 
     void 'should create requests for all scenarios from the path definition'() {
         when:
-        List<RequestScenario> requestScenarios = requestDefinition.getPossibleRequests()
+        List<RequestScenario> requestScenarios = requestDefinition.createRequests()
 
         then:
         requestScenarios.size() == 3
@@ -52,7 +52,7 @@ class RequestDefinitionTest extends Specification {
 
     void 'should create requests for all scenarios from the query definition'() {
         when:
-        List<RequestScenario> requestScenarios = requestDefinition.getPossibleRequests()
+        List<RequestScenario> requestScenarios = requestDefinition.createRequests()
 
         then:
         requestScenarios.size() == 3
@@ -65,7 +65,7 @@ class RequestDefinitionTest extends Specification {
 
     void 'should create requests for all scenarios from the body definition'() {
         when:
-        List<RequestScenario> requestScenarios = requestDefinition.getPossibleRequests()
+        List<RequestScenario> requestScenarios = requestDefinition.createRequests()
 
         then:
         requestScenarios.size() == 3
@@ -74,5 +74,66 @@ class RequestDefinitionTest extends Specification {
         requestScenarios[2].queryParameters == [queryStringField: "correct value 1"]
         requestScenarios[2].bodyParameters == [bodyStringField: 1]
         requestScenarios[2].expectedResponse == response3
+    }
+
+    void 'should create requests with empty query parameters when query definition is missing'() {
+        given:
+        requestDefinition = new RequestDefinition()
+                .withPathDefinition(pathDefinition)
+                .withBodyDefinition(bodyDefinition)
+
+        when:
+        List<RequestScenario> requestScenarios = requestDefinition.createRequests()
+
+        then:
+        requestScenarios.size() == 2
+        requestScenarios[0].name == "carId as incorrect"
+        requestScenarios[0].path == "/cars/incorrect"
+        requestScenarios[0].queryParameters == [:]
+        requestScenarios[0].bodyParameters == [bodyStringField: "correct value 2"]
+        requestScenarios[0].expectedResponse == response1
+        requestScenarios[1].name == "bodyStringField as a number"
+        requestScenarios[1].path == "/cars/123"
+        requestScenarios[1].queryParameters == [:]
+        requestScenarios[1].bodyParameters == [bodyStringField: 1]
+        requestScenarios[1].expectedResponse == response3
+    }
+
+    void 'should create requests with empty body parameters when body definition is missing'() {
+        given:
+        requestDefinition = new RequestDefinition()
+                .withPathDefinition(pathDefinition)
+                .withQueryDefinition(queryDefinition)
+
+        when:
+        List<RequestScenario> requestScenarios = requestDefinition.createRequests()
+
+        then:
+        requestScenarios.size() == 2
+        requestScenarios[0].name == "carId as incorrect"
+        requestScenarios[0].path == "/cars/incorrect"
+        requestScenarios[0].queryParameters == [queryStringField: "correct value 1"]
+        requestScenarios[0].bodyParameters == [:]
+        requestScenarios[0].expectedResponse == response1
+        requestScenarios[1].name == "queryStringField as a number"
+        requestScenarios[1].path == "/cars/123"
+        requestScenarios[1].queryParameters == [queryStringField: 1]
+        requestScenarios[1].bodyParameters == [:]
+        requestScenarios[1].expectedResponse == response2
+    }
+
+    void 'should error out when there is no path definition'() {
+        given:
+        requestDefinition = new RequestDefinition()
+                .withQueryDefinition(queryDefinition)
+                .withBodyDefinition(bodyDefinition)
+
+        when:
+        requestDefinition.createRequests()
+
+        then:
+        Exception exception = thrown(Exception)
+        exception.message == "Path definition required"
+
     }
 }

--- a/src/test/groovy/org/araneforseti/boundary/fields/ArrayFieldTest.groovy
+++ b/src/test/groovy/org/araneforseti/boundary/fields/ArrayFieldTest.groovy
@@ -14,7 +14,7 @@ class ArrayFieldTest {
     @Test
     public void optional_field_can_be_null() {
         ArrayField arrayField = new ArrayField("testField", false)
-        !scenarios_contains_value(null, arrayField)
+        assert !scenarios_contains_value(null, arrayField)
     }
 
     @Test

--- a/src/test/groovy/org/araneforseti/boundary/fields/DateFieldTest.groovy
+++ b/src/test/groovy/org/araneforseti/boundary/fields/DateFieldTest.groovy
@@ -10,32 +10,32 @@ class DateFieldTest {
 
     @Test
     public void required_field_cannot_be_empty_string() {
-        scenarios_contains_value("", requiredField)
+        assert scenarios_contains_value("", requiredField)
     }
 
     @Test
     public void optional_field_can_be_empty_string() {
-        !scenarios_contains_value("", optionalField)
+        assert !scenarios_contains_value("", optionalField)
     }
 
     @Test
     public void cannot_be_number() {
-        test_both(1)
+        assert test_both(1)
     }
 
     @Test
     public void cannot_be_boolean_true() {
-        test_both(true)
+        assert test_both(true)
     }
 
     @Test
     public void cannot_be_boolean_false() {
-        test_both(false)
+        assert test_both(false)
     }
 
     @Test
     public void cannot_be_regular_string() {
-        test_both("asdf")
+        assert test_both("asdf")
     }
 
     public boolean test_both(value) {

--- a/src/test/groovy/org/araneforseti/boundary/fields/EmailFieldTest.groovy
+++ b/src/test/groovy/org/araneforseti/boundary/fields/EmailFieldTest.groovy
@@ -10,34 +10,34 @@ class EmailFieldTest {
 
     @Test
     public void required_field_cannot_be_empty_string() {
-        scenarios_contains_value("", requiredField)
+        assert scenarios_contains_value("", requiredField)
     }
 
     @Test
     public void optional_field_can_be_empty_string() {
-        !scenarios_contains_value("", optionalField)
+        assert !scenarios_contains_value("", optionalField)
     }
 
     @Test
     public void required_field_cannot_be_null() {
-        scenarios_contains_value(null, requiredField)
+        assert scenarios_contains_value(null, requiredField)
     }
 
     @Test
     public void optional_field_can_be_null() {
-        !scenarios_contains_value(null, optionalField)
+        assert !scenarios_contains_value(null, optionalField)
     }
 
     @Test
     public void field_must_contain_at() {
-        scenarios_contains_value("testtest.com", requiredField)
-        scenarios_contains_value("testtest.com", optionalField)
+        assert scenarios_contains_value("testtest.com", requiredField)
+        assert scenarios_contains_value("testtest.com", optionalField)
     }
 
     @Test
     public void field_cannot_be_number() {
-        scenarios_contains_value(123, requiredField)
-        scenarios_contains_value(123, optionalField)
+        assert scenarios_contains_value(123, requiredField)
+        assert scenarios_contains_value(123, optionalField)
     }
 
     @Test

--- a/src/test/groovy/org/araneforseti/boundary/fields/EnumFieldTest.groovy
+++ b/src/test/groovy/org/araneforseti/boundary/fields/EnumFieldTest.groovy
@@ -9,8 +9,8 @@ class EnumFieldTest {
     EnumField optionalField = new EnumField("optionalField", ["A", "B"], true)
 
     private boolean test_both(value) {
-        scenarios_contains_value(value, requiredField)
-        scenarios_contains_value(value, optionalField)
+        assert scenarios_contains_value(value, requiredField)
+        assert scenarios_contains_value(value, optionalField)
     }
 
     @Test

--- a/src/test/groovy/org/araneforseti/boundary/fields/ObjectFieldTest.groovy
+++ b/src/test/groovy/org/araneforseti/boundary/fields/ObjectFieldTest.groovy
@@ -8,24 +8,24 @@ class ObjectFieldTest {
     @Test
     public void required_field_cannot_be_null() {
         ObjectField objectField = new ObjectField("testField", true)
-        scenarios_contains_value(null, objectField)
+        assert scenarios_contains_value(null, objectField)
     }
 
     @Test
     public void optional_field_can_be_null() {
         ObjectField objectField = new ObjectField("testField", false)
-        !scenarios_contains_value(null, objectField)
+        assert !scenarios_contains_value(null, objectField)
     }
 
     @Test
     public void gives_cases_for_fields() {
-        ObjectField objectField = new ObjectField("testField", false)
+        ObjectField objectField = new ObjectField("testField", true)
                 .withField(new BooleanField("bool", true))
                 .withField(new BooleanField("bool2", false))
-        scenarios_contains_value([bool: null, bool2: true], objectField)
-        scenarios_contains_value([bool: "a", bool2: true], objectField)
-        scenarios_contains_value([bool: 2, bool2: true], objectField)
-        scenarios_contains_value([bool2: "a", bool: true], objectField)
-        scenarios_contains_value([bool2: 2, bool: true], objectField)
+        assert scenarios_contains_value([bool: null, bool2: true], objectField)
+        assert scenarios_contains_value([bool: "a", bool2: true], objectField)
+        assert scenarios_contains_value([bool: 2, bool2: true], objectField)
+        assert scenarios_contains_value([bool2: "a", bool: true], objectField)
+        assert scenarios_contains_value([bool2: 2, bool: true], objectField)
     }
 }

--- a/src/test/groovy/org/araneforseti/boundary/mountebank/ApiHelperTest.groovy
+++ b/src/test/groovy/org/araneforseti/boundary/mountebank/ApiHelperTest.groovy
@@ -1,0 +1,146 @@
+package org.araneforseti.boundary.mountebank
+
+import groovy.json.JsonOutput
+import org.araneforseti.boundary.ApiHelper
+import org.mbtest.javabank.Client
+import org.mbtest.javabank.fluent.ImposterBuilder
+import org.mbtest.javabank.http.imposters.Imposter
+import spock.lang.Specification
+
+class ApiHelperTest extends Specification {
+    private Client mountebank
+    private int mountebankPort = 2525
+    private int imposterPort = 8080
+
+    void setup() {
+        mountebank = new Client("http://localhost:${mountebankPort}")
+        ApiHelper.baseUri = "http://localhost:${imposterPort}"
+    }
+
+    void cleanup() {
+        mountebank.deleteImposter(imposterPort)
+    }
+
+    void 'should post a resource'() {
+        given:
+        createImposterWithBody("post")
+
+        when:
+        Map response = ApiHelper.post(
+                "/path/to/resource",
+                [bodyKey: "bodyValue"],
+                [queryKey: "queryValue"],
+                [headerKey: "headerValue"])
+
+        then:
+        response.body == [message: "correct request"]
+    }
+
+    void 'should get a resource'() {
+        given:
+        createImposterWithoutBody("get")
+
+        when:
+        Map response = ApiHelper.get(
+                "/path/to/resource",
+                [queryKey: "queryValue"],
+                [headerKey: "headerValue"])
+
+        then:
+        response.body == [message: "correct request"]
+    }
+
+    void 'should delete a resource'() {
+        given:
+        createImposterWithoutBody("delete")
+
+        when:
+        Map response = ApiHelper.delete(
+                "/path/to/resource",
+                [queryKey: "queryValue"],
+                [headerKey: "headerValue"])
+
+        then:
+        response.body == [message: "correct request"]
+    }
+
+    void 'should put a resource'() {
+        given:
+        createImposterWithBody("put")
+
+        when:
+        Map response = ApiHelper.put(
+                "/path/to/resource",
+                [bodyKey: "bodyValue"],
+                [queryKey: "queryValue"],
+                [headerKey: "headerValue"])
+
+        then:
+        response.body == [message: "correct request"]
+    }
+
+    void 'should patch a resource'() {
+        given:
+        createImposterWithBody("patch")
+
+        when:
+        Map response = ApiHelper.patch(
+                "/path/to/resource",
+                [bodyKey: "bodyValue"],
+                [queryKey: "queryValue"],
+                [headerKey: "headerValue"])
+
+        then:
+        response.body == [message: "correct request"]
+    }
+
+    void createImposterWithBody(String method) {
+        Imposter imposter = new ImposterBuilder()
+                .onPort(imposterPort)
+                    .stub()
+                        .predicate()
+                            .equals()
+                                .method(method)
+                                .header("Content-Type", "application/json")
+                                .header("headerKey", "headerValue")
+                                .path("/path/to/resource")
+                                .query("queryKey", "queryValue")
+                                .body(JsonOutput.toJson([bodyKey: "bodyValue"]))
+                            .end()
+                        .end()
+                        .response()
+                            .is()
+                                .header("Content-Type", "application/json")
+                                .statusCode(400)
+                                .body("{\"message\": \"correct request\"}")
+                            .end()
+                        .end()
+                    .end()
+                .build()
+        this.mountebank.createImposter(imposter)
+    }
+
+    void createImposterWithoutBody(String method) {
+        Imposter imposter = new ImposterBuilder()
+                .onPort(imposterPort)
+                    .stub()
+                        .predicate()
+                            .equals()
+                                .method(method)
+                                .header("headerKey", "headerValue")
+                                .path("/path/to/resource")
+                                .query("queryKey", "queryValue")
+                            .end()
+                        .end()
+                        .response()
+                            .is()
+                                .header("Content-Type", "application/json")
+                                .statusCode(400)
+                                .body("{\"message\": \"correct request\"}")
+                            .end()
+                        .end()
+                    .end()
+                .build()
+        this.mountebank.createImposter(imposter)
+    }
+}

--- a/src/test/groovy/org/araneforseti/boundary/mountebank/TestBoundaryTest.groovy
+++ b/src/test/groovy/org/araneforseti/boundary/mountebank/TestBoundaryTest.groovy
@@ -1,0 +1,118 @@
+package org.araneforseti.boundary.mountebank
+
+import groovy.json.JsonOutput
+import org.araneforseti.boundary.ApiHelper
+import org.araneforseti.boundary.definitions.Definition
+import org.araneforseti.boundary.definitions.RequestDefinition
+import org.araneforseti.boundary.definitions.Response
+import org.araneforseti.boundary.definitions.path.Identifier
+import org.araneforseti.boundary.definitions.path.PathDefinition
+import org.araneforseti.boundary.definitions.path.Resource
+import org.araneforseti.boundary.fields.BooleanField
+import org.araneforseti.boundary.fields.NumberField
+import org.araneforseti.boundary.fields.StringField
+import org.mbtest.javabank.Client
+import org.mbtest.javabank.fluent.ImposterBuilder
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.lang.Unroll
+
+// This file intentionally includes failing tests
+
+class TestBoundaryTest extends Specification{
+
+    private static Client mountebank
+
+    void setupSpec() {
+        mountebank = new Client("http://localhost:2525")
+        ApiHelper.baseUri = "http://localhost:8080"
+    }
+
+    void cleanup() {
+        mountebank.deleteAllImposters()
+    }
+
+    @Shared RequestDefinition requestDefinition = new RequestDefinition()
+            .withPathDefinition(new PathDefinition()
+                .withParameter(new Resource("parent"))
+                .withParameter(new Identifier("parentId", "123")
+                    .withScenario("abc", new Response([code: 10043, message: "invalid id"], 404)))
+                .withParameter(new Resource("child")))
+            .withBodyDefinition(new Definition()
+                .withField(new StringField("stringField", "string value", true))
+                .withField(new BooleanField("booleanField", true))
+                .withField(new NumberField("numberField", false)))
+
+    @Unroll
+    void 'passing POST #name'() {
+        given:
+        setupPassingImposter(expectedResponse)
+
+        when:
+        Map response = ApiHelper.post(path, body, query)
+
+        then:
+        response.statusCode == expectedResponse.statusCode
+        response.body == expectedResponse.body
+
+        where:
+        request << requestDefinition.createRequests()
+        name = request.name
+        path = request.path
+        query = request.queryParameters
+        body = request.bodyParameters
+        expectedResponse = request.expectedResponse
+    }
+
+    @Unroll
+    void 'failing POST #name'() {
+        given:
+        setupFailingImposter()
+
+        when:
+        Map response = ApiHelper.post(path, body, query)
+
+        then:
+        response.statusCode == expectedResponse.statusCode
+        response.body == expectedResponse.body
+
+        where:
+        request << requestDefinition.createRequests()
+        name = request.name
+        path = request.path
+        query = request.queryParameters
+        body = request.bodyParameters
+        expectedResponse = request.expectedResponse
+    }
+
+
+    def setupPassingImposter(Response expectedResponse) {
+        mountebank.createImposter(new ImposterBuilder()
+            .onPort(8080)
+                .stub()
+                    .response()
+                        .is()
+                            .header("Content-Type", "application/json")
+                            .statusCode(expectedResponse.statusCode)
+                            .body(JsonOutput.toJson(expectedResponse.body))
+                        .end()
+                    .end()
+                .end()
+            .build())
+    }
+
+    def setupFailingImposter() {
+        mountebank.createImposter(new ImposterBuilder()
+            .onPort(8080)
+                .stub()
+                    .response()
+                        .is()
+                            .header("Content-Type", "application/json")
+                            .statusCode(400)
+                            .body(JsonOutput.toJson([key: "value"]))
+                        .end()
+                    .end()
+                .end()
+            .build())
+    }
+}


### PR DESCRIPTION
Added a PathDefinition which allows you to define a path with resources and identifiers. The definition will generate scenarios that can be used to test path parameter validation. Also added a RequestDefinition, which uses definitions for the path, query, and body of a request to build scenarios that have values for all parts of a request. See TestBoundaryTest (you will have to install and run mountebank for it to work properly).

Began adding an `expectedResponse` field alongside `expectedMessage`, with the intent of eventually replacing it. This would allow a more complete definition of the expected response. 

Lastly added a helper class to wrap HttpBuilder. Wasn't sure whether to put it in `main` or `test` but i went with `main` as it could be incorporated into a test runner as part of the framework.